### PR TITLE
Add 3-column flex layout (1:5:1 ratio)

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -112,6 +112,51 @@
   background-color: var(--bg-muted) !important;
 }
 
+/* --- 3-Column Flex Layout (1:5:1) --- */
+.md-main__inner {
+  display: flex;
+  max-width: 100%;
+}
+
+/* Left sidebar — 1 part */
+.md-main__inner > .md-sidebar--primary {
+  flex: 1 1 0%;
+  min-width: 0;
+  text-align: left;
+}
+
+/* Main content — 5 parts */
+.md-main__inner > .md-content {
+  flex: 5 1 0%;
+  min-width: 0;
+  max-width: none;
+}
+
+/* Right sidebar — 1 part */
+.md-main__inner > .md-sidebar--secondary {
+  flex: 1 1 0%;
+  min-width: 0;
+  text-align: right;
+}
+
+.md-main__inner > .md-sidebar--secondary .md-nav__list {
+  text-align: left;
+}
+
+/* Responsive: stack on smaller screens */
+@media screen and (max-width: 76.1875em) {
+  .md-main__inner {
+    flex-wrap: wrap;
+  }
+  .md-main__inner > .md-sidebar--primary,
+  .md-main__inner > .md-sidebar--secondary {
+    flex: 0 0 100%;
+  }
+  .md-main__inner > .md-content {
+    flex: 0 0 100%;
+  }
+}
+
 /* --- Content Area --- */
 .md-content {
   background-color: #ffffff !important;


### PR DESCRIPTION
## Summary
- Added flexbox 3-column layout for left sidebar, content area, and right sidebar
- Columns use a 1:5:1 ratio for balanced proportions
- Responsive breakpoint at 76.1875em stacks columns on smaller screens

## Test plan
- [ ] Verify layout renders correctly on desktop (3 columns visible)
- [ ] Resize browser to confirm columns stack on tablet/mobile
- [ ] Check left sidebar is left-aligned and right sidebar is right-aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)