### PR TITLE
Remove pilcrow permalinks from headings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,7 +65,7 @@ markdown_extensions:
   - md_in_html
   - tables
   - toc:
-      permalink: true
+      permalink: false
   - pymdownx.arithmatex:
       generic: true
   - pymdownx.betterem


### PR DESCRIPTION
## Summary
- Set `permalink: false` in toc config to remove ¶ symbols from headings

🤖 Generated with [Claude Code](https://claude.com/claude-code)