### PR TITLE
Fix permission matrix icon colors for SVG

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -525,8 +525,16 @@ details.question > ul {
   color: #16a34a !important;
 }
 
+.md-typeset .green svg {
+  fill: #16a34a !important;
+}
+
 .md-typeset .red {
   color: #dc2626 !important;
+}
+
+.md-typeset .red svg {
+  fill: #dc2626 !important;
 }
 
 /* --- Transitions (global polish) --- */


### PR DESCRIPTION
## Summary
- Added SVG `fill` targeting for `.green` and `.red` classes so Material icons render in the correct colors

## Test plan
- [ ] Check permission matrix on Roles & Permissions page shows green ticks and red crosses

🤖 Generated with [Claude Code](https://claude.com/claude-code)